### PR TITLE
Added ability to keep tactical camera pitch locked when unlocking pitch

### DIFF
--- a/src/CameraTweaksManager.h
+++ b/src/CameraTweaksManager.h
@@ -12,8 +12,10 @@ class CameraTweaks : public DKUtil::model::Singleton<CameraTweaks>
 public:
     enum class CameraMode : uint8_t
     {
-        kExploration,
+		kExploration,
+		kExplorationTactical,
 		kCombat,
+		kCombatTactical,
 		kFreeCamera
     };
 
@@ -37,6 +39,7 @@ public:
 	static CameraMode GetCurrentCameraMode(uint32_t a_cameraModeFlags);
 	bool IsCameraUnlocked(int16_t a_playerId, RE::CameraObject* a_cameraObject) const;
 	bool CanAdjustPitch(RE::CameraObject* a_cameraObject) const;
+	bool CanAdjustPitch(CameraTweaks::CameraMode cameraMode) const;
 
 	bool ShouldSkipToggleInputMode(int16_t a_playerId) const { return GetPlayerData(a_playerId).bSkipToggleInputMode; }
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -13,6 +13,7 @@ namespace Settings
 
 
 			config.Bind(ExplorationUnlockPitch, true);
+			config.Bind(ExplorationKeepTacticalPitchLocked, false);
 			config.Bind<-89, 89>(ExplorationUnlockedPitchMin, -85.f);
 			config.Bind<-89, 89>(ExplorationUnlockedPitchMax, 85.f);
 			config.Bind(ExplorationOverrideLockedPitch, false);
@@ -44,6 +45,7 @@ namespace Settings
 
 
 			config.Bind(CombatUnlockPitch, true);
+			config.Bind(CombatKeepTacticalPitchLocked, false);
 			config.Bind<-89, 89>(CombatUnlockedPitchMin, -85.f);
 			config.Bind<-89, 89>(CombatUnlockedPitchMax, 85.f);
 			config.Bind(CombatOverrideLockedPitch, false);

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -15,6 +15,7 @@ namespace Settings
 
 
 		Boolean ExplorationUnlockPitch{ "ExplorationUnlockPitch", "ExplorationPitch" };
+		Boolean ExplorationKeepTacticalPitchLocked{ "ExplorationKeepTacticalPitchLocked", "ExplorationPitch" };
 		Double ExplorationUnlockedPitchMin{ "ExplorationUnlockedPitchMin", "ExplorationPitch" };
 		Double ExplorationUnlockedPitchMax{ "ExplorationUnlockedPitchMax", "ExplorationPitch" };
 		Boolean ExplorationOverrideLockedPitch{ "ExplorationOverrideLockedPitch", "ExplorationPitch" };
@@ -46,6 +47,7 @@ namespace Settings
 
 
 		Boolean CombatUnlockPitch{ "CombatUnlockPitch", "CombatPitch" };
+		Boolean CombatKeepTacticalPitchLocked{ "CombatKeepTacticalPitchLocked", "CombatPitch" };
 		Double CombatUnlockedPitchMin{ "CombatUnlockedPitchMin", "CombatPitch" };
 		Double CombatUnlockedPitchMax{ "CombatUnlockedPitchMax", "CombatPitch" };
 		Boolean CombatOverrideLockedPitch{ "CombatOverrideLockedPitch", "CombatPitch" };


### PR DESCRIPTION
When ExplorationUnlockPitch or CombatUnlockPitch are true, ExplorationKeepTacticalPitchLocked and CombatKeepTacticalPitchLocked can be set to true to override the behaviour when in tactical camera. This can also interact with the settings for locked pitch overrides for tactical camera.